### PR TITLE
Check if the current user is not null before setting user id to analytics provider.

### DIFF
--- a/app/src/main/java/com/ndhunju/relay/RelayApplication.kt
+++ b/app/src/main/java/com/ndhunju/relay/RelayApplication.kt
@@ -57,6 +57,8 @@ class RelayApplication: Application() {
     }
 
     private fun setUpAnalyticsManager() {
-        appComponent.analyticsProvider().setUserId(appComponent.currentUser().user.id)
+        if (appComponent.currentUser().user.id) {
+            appComponent.analyticsProvider().setUserId(appComponent.currentUser().user.id)
+        }
     }
 }


### PR DESCRIPTION
The app crashes at first start up as it is not checking if the current user is null before setting the user id to analytics providers.